### PR TITLE
Release 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 Each new release typically also includes the latest modulesync defaults.
 These should not affect the functionality of the module.
 
+## [v3.2.0](https://github.com/lsst-it/puppet-helm_binary/tree/v3.2.0) (2025-10-24)
+
+[Full Changelog](https://github.com/lsst-it/puppet-helm_binary/compare/v3.1.0...v3.2.0)
+
+**Implemented enhancements:**
+
+- \(metadata.json\) bump archiver constraint to inlude 9 [\#43](https://github.com/lsst-it/puppet-helm_binary/pull/43) ([badenerb](https://github.com/badenerb))
+- Update actions/checkout action to v5 [\#36](https://github.com/lsst-it/puppet-helm_binary/pull/36) ([renovate[bot]](https://github.com/apps/renovate))
+
 ## [v3.1.0](https://github.com/lsst-it/puppet-helm_binary/tree/v3.1.0) (2025-04-01)
 
 [Full Changelog](https://github.com/lsst-it/puppet-helm_binary/compare/v3.0.0...v3.1.0)

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "lsst-helm_binary",
-  "version": "3.1.1-rc0",
+  "version": "3.2.0",
   "author": "AURA/LSST/Rubin Observatory",
   "summary": "Helm binary module",
   "license": "Apache-2.0",


### PR DESCRIPTION
Automated release-prep through https://github.com/voxpupuli/gha-puppet/ from commit 3e68667476c794f05465da864c7fecfa1bd5ccb5.
Checkout the [module release instructions](https://voxpupuli.org/docs/releasing_version/).